### PR TITLE
Implement pending transactions & match validation

### DIFF
--- a/admin-ui/components/TransactionsTable.tsx
+++ b/admin-ui/components/TransactionsTable.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { useEffect, useState } from 'react';
 import * as RadixButton from '@radix-ui/react-slot';
-import { getPendingTransactions, approveTransaction } from '@/lib/api';
+import { getPendingTransactions, approveTransaction, cancelTransaction } from '@/lib/api';
 
 interface Transaction {
   id: string;
@@ -28,6 +28,11 @@ export default function TransactionsTable() {
     setTransactions((prev) => prev.filter((t) => t.id !== id));
   };
 
+  const handleCancel = async (id: string) => {
+    await cancelTransaction(id);
+    setTransactions((prev) => prev.filter((t) => t.id !== id));
+  };
+
   if (loading) return <p>Loading...</p>;
   if (error) return <p className="text-red-600">{error}</p>;
 
@@ -47,12 +52,18 @@ export default function TransactionsTable() {
             <td className="border-b p-2">{t.jugadorId}</td>
             <td className="border-b p-2">{t.monto}</td>
             <td className="border-b p-2">{t.tipo}</td>
-            <td className="border-b p-2">
+            <td className="border-b p-2 space-x-2">
               <RadixButton.Slot
                 className="bg-blue-600 text-white px-2 py-1 rounded"
                 onClick={() => handleApprove(t.id)}
               >
                 Aprobar
+              </RadixButton.Slot>
+              <RadixButton.Slot
+                className="bg-red-600 text-white px-2 py-1 rounded"
+                onClick={() => handleCancel(t.id)}
+              >
+                Cancelar
               </RadixButton.Slot>
             </td>
           </tr>

--- a/admin-ui/lib/api.ts
+++ b/admin-ui/lib/api.ts
@@ -16,6 +16,14 @@ export async function approveTransaction(id: string) {
   return res.json();
 }
 
+export async function cancelTransaction(id: string) {
+  const res = await fetch(`${API_BASE}/transacciones/${id}/cancelar`, { method: "POST" });
+  if (!res.ok) {
+    throw new Error("Failed to cancel transaction");
+  }
+  return res.json();
+}
+
 export async function getPendingMatches() {
   const res = await fetch(`${API_BASE}/partidas/pendientes`, { cache: "no-store" });
   if (!res.ok) {

--- a/src/main/java/co/com/arena/real/application/controller/PartidaController.java
+++ b/src/main/java/co/com/arena/real/application/controller/PartidaController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
 import java.util.UUID;
 
 @RestController
@@ -21,6 +22,13 @@ import java.util.UUID;
 public class PartidaController {
 
     private final PartidaService partidaService;
+
+    @GetMapping("/pendientes")
+    @Operation(summary = "Listar pendientes", description = "Obtiene partidas que deben ser validadas")
+    public ResponseEntity<List<PartidaResponse>> listarPendientes() {
+        List<PartidaResponse> lista = partidaService.listarPendientes();
+        return ResponseEntity.ok(lista);
+    }
 
     @GetMapping("/apuesta/{apuestaId}")
     @Operation(summary = "Buscar por apuesta", description = "Obtiene la partida asociada a una apuesta")

--- a/src/main/java/co/com/arena/real/application/controller/TransaccionController.java
+++ b/src/main/java/co/com/arena/real/application/controller/TransaccionController.java
@@ -43,6 +43,13 @@ public class TransaccionController {
         return ResponseEntity.ok(lista);
     }
 
+    @GetMapping("/pendientes")
+    @Operation(summary = "Listar pendientes", description = "Obtiene las transacciones pendientes")
+    public ResponseEntity<List<TransaccionResponse>> listarPendientes() {
+        List<TransaccionResponse> lista = transaccionService.listarPendientes();
+        return ResponseEntity.ok(lista);
+    }
+
     @GetMapping("/stream/{jugadorId}")
     public SseEmitter stream(@PathVariable String jugadorId) {
         return sseService.subscribe(jugadorId); // <- usando tu SseService refactorizado
@@ -54,6 +61,13 @@ public class TransaccionController {
         TransaccionResponse response = transaccionService.aprobarTransaccion(id);
         return ResponseEntity.ok(response);
 
+    }
+
+    @PostMapping("/{id}/cancelar")
+    @Operation(summary = "Cancelar transacción", description = "Marca la transacción como rechazada")
+    public ResponseEntity<TransaccionResponse> cancelar(@PathVariable UUID id) {
+        TransaccionResponse response = transaccionService.cancelarTransaccion(id);
+        return ResponseEntity.ok(response);
     }
 
 }

--- a/src/main/java/co/com/arena/real/application/service/PartidaService.java
+++ b/src/main/java/co/com/arena/real/application/service/PartidaService.java
@@ -18,6 +18,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -40,6 +41,12 @@ public class PartidaService {
         return partidaRepository.findById(partidaId)
                 .filter(p -> p.getEstado() == EstadoPartida.EN_CURSO || p.getEstado() == EstadoPartida.POR_APROBAR)
                 .map(Partida::getChatId);
+    }
+
+    public List<PartidaResponse> listarPendientes() {
+        return partidaRepository.findByEstado(EstadoPartida.POR_APROBAR).stream()
+                .map(partidaMapper::toDto)
+                .toList();
     }
 
     @Transactional

--- a/src/main/java/co/com/arena/real/infrastructure/dto/rs/PartidaResponse.java
+++ b/src/main/java/co/com/arena/real/infrastructure/dto/rs/PartidaResponse.java
@@ -10,6 +10,8 @@ import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+import co.com.arena.real.domain.entity.partida.ModoJuego;
+
 
 @Data
 @NoArgsConstructor
@@ -21,6 +23,7 @@ public class PartidaResponse implements Serializable {
 
     private UUID id;
     private UUID apuestaId;
+    private ModoJuego modoJuego;
     private String ganadorId;
     private boolean validada;
     private LocalDateTime validadaEn;

--- a/src/main/java/co/com/arena/real/infrastructure/mapper/PartidaMapper.java
+++ b/src/main/java/co/com/arena/real/infrastructure/mapper/PartidaMapper.java
@@ -14,6 +14,7 @@ public class PartidaMapper {
         return PartidaResponse.builder()
                 .id(entity.getId())
                 .apuestaId(entity.getApuesta() != null ? entity.getApuesta().getId() : null)
+                .modoJuego(entity.getModoJuego())
                 .ganadorId(entity.getGanador() != null ? entity.getGanador().getId() : null)
                 .validada(entity.isValidada())
                 .validadaEn(entity.getValidadaEn())

--- a/src/main/java/co/com/arena/real/infrastructure/repository/PartidaRepository.java
+++ b/src/main/java/co/com/arena/real/infrastructure/repository/PartidaRepository.java
@@ -1,12 +1,16 @@
 package co.com.arena.real.infrastructure.repository;
 
+import co.com.arena.real.domain.entity.partida.EstadoPartida;
 import co.com.arena.real.domain.entity.partida.Partida;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface PartidaRepository extends JpaRepository<Partida, UUID> {
     Optional<Partida> findByApuesta_Id(UUID apuestaId);
+
+    List<Partida> findByEstado(EstadoPartida estado);
 
 }

--- a/src/main/java/co/com/arena/real/infrastructure/repository/TransaccionRepository.java
+++ b/src/main/java/co/com/arena/real/infrastructure/repository/TransaccionRepository.java
@@ -1,5 +1,6 @@
 package co.com.arena.real.infrastructure.repository;
 
+import co.com.arena.real.domain.entity.EstadoTransaccion;
 import co.com.arena.real.domain.entity.Transaccion;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -8,4 +9,6 @@ import java.util.UUID;
 
 public interface TransaccionRepository extends JpaRepository<Transaccion, UUID> {
     List<Transaccion> findByJugador_Id(String jugadorId);
+
+    List<Transaccion> findByEstado(EstadoTransaccion estado);
 }


### PR DESCRIPTION
## Summary
- fetch pending transactions and allow canceling
- expose API to list, approve or cancel transactions
- expose API to list pending matches
- extend match response with mode
- show cancel button in admin UI

## Testing
- `npm run lint`
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_b_685df7228408832dba44688c93f50ef1