### PR TITLE
Add endpoints to manage bets and matches

### DIFF
--- a/src/main/java/co/com/arena/real/application/controller/ApuestaController.java
+++ b/src/main/java/co/com/arena/real/application/controller/ApuestaController.java
@@ -7,12 +7,9 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.UUID;
 
 @RestController
@@ -22,6 +19,23 @@ import java.util.UUID;
 public class ApuestaController {
 
     private final ApuestaService apuestaService;
+
+    @GetMapping
+    @Operation(summary = "Listar", description = "Obtiene todas las apuestas o filtra por estado")
+    public ResponseEntity<List<ApuestaResponse>> listar(@RequestParam(value = "estado", required = false) EstadoApuesta estado) {
+        List<ApuestaResponse> lista = (estado == null)
+                ? apuestaService.listarTodas()
+                : apuestaService.listarPorEstado(estado);
+        return ResponseEntity.ok(lista);
+    }
+
+    @GetMapping("/{id}")
+    @Operation(summary = "Obtener", description = "Obtiene una apuesta por su identificador")
+    public ResponseEntity<ApuestaResponse> obtener(@PathVariable UUID id) {
+        return apuestaService.obtenerPorId(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
 
     @PutMapping("/{id}/estado")
     @Operation(summary = "Cambiar estado", description = "Actualiza el estado de una apuesta")

--- a/src/main/java/co/com/arena/real/application/controller/PartidaController.java
+++ b/src/main/java/co/com/arena/real/application/controller/PartidaController.java
@@ -2,15 +2,12 @@ package co.com.arena.real.application.controller;
 
 import co.com.arena.real.application.service.PartidaService;
 import co.com.arena.real.infrastructure.dto.rs.PartidaResponse;
+import co.com.arena.real.domain.entity.partida.EstadoPartida;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.UUID;
@@ -23,6 +20,15 @@ public class PartidaController {
 
     private final PartidaService partidaService;
 
+    @GetMapping
+    @Operation(summary = "Listar", description = "Obtiene todas las partidas o filtra por estado")
+    public ResponseEntity<List<PartidaResponse>> listar(@RequestParam(value = "estado", required = false) EstadoPartida estado) {
+        List<PartidaResponse> lista = (estado == null)
+                ? partidaService.listarTodas()
+                : partidaService.listarPorEstado(estado);
+        return ResponseEntity.ok(lista);
+    }
+
     @GetMapping("/pendientes")
     @Operation(summary = "Listar pendientes", description = "Obtiene partidas que deben ser validadas")
     public ResponseEntity<List<PartidaResponse>> listarPendientes() {
@@ -34,6 +40,14 @@ public class PartidaController {
     @Operation(summary = "Buscar por apuesta", description = "Obtiene la partida asociada a una apuesta")
     public ResponseEntity<PartidaResponse> obtenerPorApuesta(@PathVariable UUID apuestaId) {
         return partidaService.obtenerPorApuestaId(apuestaId)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @GetMapping("/{id}")
+    @Operation(summary = "Obtener", description = "Obtiene una partida por su identificador")
+    public ResponseEntity<PartidaResponse> obtenerPorId(@PathVariable UUID id) {
+        return partidaService.obtenerPorId(id)
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());
     }

--- a/src/main/java/co/com/arena/real/application/service/ApuestaService.java
+++ b/src/main/java/co/com/arena/real/application/service/ApuestaService.java
@@ -12,6 +12,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
+import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -31,5 +33,22 @@ public class ApuestaService {
         apuesta.setEstado(estado);
         Apuesta saved = apuestaRepository.save(apuesta);
         return ApuestaMapper.toDto(saved);
+    }
+
+    public List<ApuestaResponse> listarTodas() {
+        return apuestaRepository.findAll().stream()
+                .map(ApuestaMapper::toDto)
+                .toList();
+    }
+
+    public List<ApuestaResponse> listarPorEstado(EstadoApuesta estado) {
+        return apuestaRepository.findByEstado(estado).stream()
+                .map(ApuestaMapper::toDto)
+                .toList();
+    }
+
+    public Optional<ApuestaResponse> obtenerPorId(UUID id) {
+        return apuestaRepository.findById(id)
+                .map(ApuestaMapper::toDto);
     }
 }

--- a/src/main/java/co/com/arena/real/application/service/PartidaService.java
+++ b/src/main/java/co/com/arena/real/application/service/PartidaService.java
@@ -49,6 +49,23 @@ public class PartidaService {
                 .toList();
     }
 
+    public List<PartidaResponse> listarTodas() {
+        return partidaRepository.findAll().stream()
+                .map(partidaMapper::toDto)
+                .toList();
+    }
+
+    public List<PartidaResponse> listarPorEstado(EstadoPartida estado) {
+        return partidaRepository.findByEstado(estado).stream()
+                .map(partidaMapper::toDto)
+                .toList();
+    }
+
+    public Optional<PartidaResponse> obtenerPorId(UUID id) {
+        return partidaRepository.findById(id)
+                .map(partidaMapper::toDto);
+    }
+
     @Transactional
     public PartidaResponse marcarComoValidada(UUID partidaId) {
         Partida partida = partidaRepository.findById(partidaId)

--- a/src/main/java/co/com/arena/real/infrastructure/repository/ApuestaRepository.java
+++ b/src/main/java/co/com/arena/real/infrastructure/repository/ApuestaRepository.java
@@ -1,9 +1,13 @@
 package co.com.arena.real.infrastructure.repository;
 
 import co.com.arena.real.domain.entity.Apuesta;
+import co.com.arena.real.domain.entity.EstadoApuesta;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.UUID;
 
+import java.util.List;
+
 public interface ApuestaRepository extends JpaRepository<Apuesta, UUID> {
+    List<Apuesta> findByEstado(EstadoApuesta estado);
 }


### PR DESCRIPTION
## Summary
- allow listing bets and looking up bets by ID
- support listing matches with optional status filter and getting matches by ID
- expose new service methods and repository finder methods

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_685e13a45084832da0477a7061861ea1